### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 Calligraphy for Xamarin
 ===========
 
-A Xamarin port of the Android Calligraphy library from [Christopher Jenkins](https://github.com/chrisjenx/Calligraphy).
-
-## Known Issue
-
-No support for Android 5 / appcompat21 yet (i.e. no custom font in toolbar)
+A Xamarin binding of the Android Calligraphy library from [Christopher Jenkins](https://github.com/chrisjenx/Calligraphy).
 
 ##Getting started
 
@@ -19,7 +15,9 @@ Install-Package CallygraphyXamarin
 
 ### Fonts
 
-Add your custom fonts to `assets/fonts/` all font definitions are relative to this path. 
+Add your custom fonts to `assets/fonts/` all font definitions are relative to this path.
+
+_Note: Be sure to set the build action to AndroidAsset; otherwise Android will default to the theme font.
 
 ### Configuration
 
@@ -31,7 +29,15 @@ needs to be defined before that.
 public override void OnCreate()
         {
             base.OnCreate();
-            CalligraphyConfig.InitDefault("fonts/GothamHTF-Light.ttf", Calligraphy.Resource.Attribute.fontPath);
+            CalligraphyConfig.InitDefault(new CalligraphyConfig.Builder()
+                    .SetDefaultFontPath("fonts/gtw.ttf")
+                    .SetFontAttrId(Resource.Attribute.fontPath)
+                // Adding a custom view that support adding a typeFace
+                    // .AddCustomViewWithSetTypeface(Java.Lang.Class.FromType(typeof(CustomViewWithTypefaceSupport)))
+                // Adding a custom style
+                    // .AddCustomStyle(Java.Lang.Class.FromType(typeof(TextField)), Resource.Attribute.textFieldStyle)
+                .Build()
+            );
         }
 }
 ```
@@ -43,13 +49,13 @@ no default font. I recommend defining at least a default font or attribute._
 Wrap the Activity Context:
 
 ```csharp
- protected override void AttachBaseContext(Context context)
+        protected override void AttachBaseContext(Context context)
         {
-            base.AttachBaseContext(new CalligraphyContextWrapper(context));
+            base.AttachBaseContext(CalligraphyContextWrapper.Wrap(context));
         }
 ```
 
-_You're good to go!_
+_You're ready to go!_
 
 
 ## Usage
@@ -127,7 +133,7 @@ The `CalligraphyFactory` looks for the font in a pretty specific order, for the 
 
 #Note
 
-I could have used a Jar binding project, but I decided to migrate the code instead. Plus you get a NuGet package. And the custom attribute is free out of the bo.x
+I could have used a Jar binding project, but I decided to migrate the code instead. Plus you get a NuGet package. And the custom attribute is free out of the box
 
 
 #Licence


### PR DESCRIPTION
- Android 5 / appcompat21 not working line removed. API's 21+ seem to work fine with aar binding.
- I may have spent a few hours pulling hair before working out the fonts need to have the build action set to AndroidAssets. 
